### PR TITLE
Add a sample config

### DIFF
--- a/resources/sample.mpDris.conf
+++ b/resources/sample.mpDris.conf
@@ -1,0 +1,27 @@
+# The ip-address that MPD runs on
+# While this can be a different machine than your own, this is very unlikely,
+# so in almost every case you can just leave it as the default value
+#
+# addr = "127.0.0.1"
+
+# The TCP port that MPD listens on for its API, configured in mpd.conf or 6600
+#
+# port = 6600
+
+# The amount of times to retry to get a connection to MPD before exiting
+#
+# retries = 3
+
+# The root directory where your music is stored, configured in mpd.conf
+# It is very likely that this is just ~/Music
+# Note: while there is shell escaping, the brace syntax (${varname}) is as of v.1.2.0 not supported
+#
+# mpDris will search this directory for covers like this:
+# - $music_directory/covers/$song_path/$filename.$ext
+# - $music_directory/$song_path/$filename.$ext
+# - $music_directory/$song_path/cover.$ext
+#
+# $ext can be one of the following values: jpg, jpeg, png, webp, avif, jxl, bmp, gif, heif, heic
+# For more detail on covers, please read the Configuration section of the README
+#
+# music_directory = "~/Music"

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,19 +171,14 @@ impl Config {
 }
 
 fn default_music_dir() -> Box<str> {
-    let dir = format!("{}/Music", *HOME_DIR).into_boxed_str();
-    eprintln!("Missing value `music_directory` in config, using default: {dir}");
-    dir
+    format!("{}/Music", *HOME_DIR).into_boxed_str()
 }
 fn default_addr() -> IpAddr {
-    eprintln!("Missing value `addr` in config, using default: {DEFAULT_ADDR}");
     DEFAULT_ADDR
 }
 fn default_port() -> u16 {
-    eprintln!("Missing value `port` in config, using default: {DEFAULT_PORT}");
     DEFAULT_PORT
 }
 fn default_retries() -> isize {
-    eprintln!("Missing value `retries` in config, using default: {DEFAULT_RETRIES}");
     DEFAULT_RETRIES
 }


### PR DESCRIPTION
With this PR we do three things:
1. Remove the warning messages that you'd get when a value was missing in the config
2. Add a sample configuration
3. A small format fix to use map_err()? instead of match when only needing to early return