### PR TITLE
Fix bugs

### DIFF
--- a/src/dbus/player.rs
+++ b/src/dbus/player.rs
@@ -295,8 +295,8 @@ impl PlayerInterface {
 
     #[zbus(property)]
     async fn set_volume(&self, volume: f64) -> zbus::Result<()> {
-        if volume > 100.0 {
-            return Err(fdo::Error::InvalidArgs(String::from("Volume cannot be greater than 100")).into());
+        if volume < 0.0 || volume > 100.0 {
+            return Err(fdo::Error::InvalidArgs(String::from("Volume must be between 0 and 100")).into());
         }
 
         match self.mpd.request_data(&format!("setvol {}", volume as u8)).await {


### PR DESCRIPTION
Fix two bugs:
1. When reloading the config before we now wait for the reconnect function to finish before attempting to reaquire a lock on the idle connection.
2. Add a lower bound to the set_volume function in the Player interface, so that any volume outside 0 and 100 gets rejected (before we just had an upper bound)