### PR TITLE
Add format and lint jobs to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build, test and lint
 
 on:
   push:
@@ -9,10 +9,43 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: full
 
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Check formatting
+        run: |
+          cargo --locked fmt --check
+          cargo --locked check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Catch clippy mistakes
+        run: |
+          cargo --locked clippy
+
   build:
     runs-on: ubuntu-latest
+    needs: [fmt, clippy]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -20,7 +53,8 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: stable
-    - name: Build package
-      run: cargo build --verbose
+    - uses: Swatinem/rust-cache@v2
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo --locked test --verbose
+    - name: Build package
+      run: cargo --locked build --verbose


### PR DESCRIPTION
Add two more jobs to the build workflow that run cargo check, fmt and clippy to check for common errors.