### PR TITLE
Add dirname covers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
 A lightweight application that implements the media player D-Bus interface [MPRIS](https://wiki.archlinux.org/title/MPRIS) for the [Music Player Daemon (MPD)](https://musicpd.com).
 
 
+__Table of Contents:__
+* [Dependencies](#dependencies)
+* [Installation](#installation)
+* [Configuration](#configuration)
+* [Roadmap](#roadmap)
+* [Contributing](#contributing)
+* [Licence](#licence)
+* [Authors](#authors)
+
+
 ## Dependencies
 
 ### Runtime
@@ -130,6 +140,7 @@ If you have the song `Resurrections.mp3` in `/home/johndoe/Music/Celeste/`, mpDr
 - [ ] implement tracklist interface
 
 
+
 ## Contributing
 Contributions are always welcome!
 
@@ -143,4 +154,3 @@ The Project is Licensed under the [MIT Licence](https://github.com/jasger9000/mp
 
 ## Authors
 - [@jasger9000](https://www.github.com/jasger9000)
-

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ The config file has the following options:
 This directory will be searched for image files that correspond to the currently playing song to display as cover art.
 
 #### Example:
-Let's say you have a user who stores their Music in `~/Music` and set their `cover_directory` to be in `~/Music/Pictures/songcovers`.
-If they now play the song `Resurrections.mp3` located in `~/Music/Celeste`,
-mpDris will search in `~/Pictures/songcovers/Celeste/` for a file named Resurrections with one of the following file extensions:
+Let's say you have a user who stores their Music in `~/Music` and set their `cover_directory` to be in `~/Music/Pictures/songcovers`.<br />
+If they now play the song `Resurrections.mp3` located in `~/Music/Celeste`,<br />
+mpDris will search in `~/Pictures/songcovers/Celeste/` for a file named Resurrections with one of the following file extensions:<br />
 `jpg`, `jpeg`, `png`, `webp`, `avif`, `jxl`, `bmp`, `gif`, `heif` and `heic`.
 
 ### music_directory
@@ -144,7 +144,7 @@ If you have the song `Resurrections.mp3` in `/home/johndoe/Music/Celeste/`, mpDr
 ## Contributing
 Contributions are always welcome!
 
-If you feel there's something missing/wrong/something that could be improved please open an [issue](https://github.com/jasger9000/mpDris/issues).
+If you feel there's something missing/wrong/something that could be improved please open an [issue](https://github.com/jasger9000/mpDris/issues).<br />
 Or if you want to add something yourself, just [open a pull request](https://github.com/jasger9000/mpDris/pulls) and I will have a look at it as soon as I can.
 
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ If they now play the song `Resurrections.mp3` located in `~/Music/Celeste`,<br /
 mpDris will search in `~/Pictures/songcovers/Celeste/` for a file named Resurrections with one of the following file extensions:<br />
 `jpg`, `jpeg`, `png`, `webp`, `avif`, `jxl`, `bmp`, `gif`, `heif` and `heic`.
 
+Alternatively if the song is located in a sub-directory, you can name a cover file the same name as the directory
+and it will be used for every song in that directory.<br />
+So sticking with the example from above, mpDris will search for a file in `~/Pictures/songcovers/`
+named Celeste with one of the above listed extensions.
+
+
 ### music_directory
 Like cover_directory, this directory can also be used to find covers.
 MpDris will search the following paths for song covers, using the first one it finds:

--- a/resources/sample.mpDris.conf
+++ b/resources/sample.mpDris.conf
@@ -37,4 +37,9 @@
 # If they now play the song Resurrections.mp3 located in ~/Music/Celeste, mpDris will search in
 # ~/Pictures/songcovers/Celeste/ for a file named Resurrections with one of the above mentioned file extensions.
 #
+# Alternatively if the song is located in a sub-directory, you can name a cover file the same name as the directory
+# and it will be used for every song in that directory.
+# So sticking with the example from above, mpDris will search for a file named Celeste in cover_directory
+# with one of the above listed extensions.
+#
 # cover_directory = "~/Music/covers"

--- a/src/client/status.rs
+++ b/src/client/status.rs
@@ -109,13 +109,14 @@ impl Song {
         debug!("searching cover for '{}'", self.uri.display());
 
         let paths = {
+            let mut vec = Vec::new();
             let c = config().read().await;
 
-            let covers_dir = c.cover_directory.join(&*self.uri);
-            let same_dir = c.music_directory.join(&*self.uri);
-            let cover_file = same_dir.with_file_name("cover");
+            vec.push(c.cover_directory.join(&*self.uri));
+            vec.push(c.music_directory.join(&*self.uri));
+            vec.push(vec[vec.len() - 1].with_file_name("cover"));
 
-            [covers_dir, same_dir, cover_file]
+            vec
         };
 
         for mut path in paths {

--- a/src/client/status.rs
+++ b/src/client/status.rs
@@ -113,6 +113,14 @@ impl Song {
             let c = config().read().await;
 
             vec.push(c.cover_directory.join(&*self.uri));
+            // Music/Celeste/Resurrections.mp3 -> covers/Celeste
+            if let Some(p) = self.uri.parent() {
+                if p.parent().is_some() {
+                    // p.parent() is none if p = ""
+                    vec.push(c.cover_directory.join(p));
+                }
+            }
+
             vec.push(c.music_directory.join(&*self.uri));
             vec.push(vec[vec.len() - 1].with_file_name("cover"));
 

--- a/src/client/status.rs
+++ b/src/client/status.rs
@@ -1,8 +1,6 @@
 use async_std::channel::Sender;
 use log::debug;
-use std::mem::replace;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{mem::replace, path::PathBuf, sync::Arc, time::Duration};
 
 use crate::config::config;
 
@@ -65,7 +63,7 @@ pub enum Repeat {
 
 #[derive(Debug, Clone)]
 pub struct Song {
-    pub uri: Arc<str>,
+    pub uri: PathBuf,
     pub cover: Option<Arc<str>>,
     pub artists: Vec<Arc<str>>,
     pub album: Option<Arc<str>>,
@@ -91,7 +89,7 @@ impl Song {
     /// Creates a new empty song
     pub fn new() -> Self {
         Self {
-            uri: "".into(),
+            uri: PathBuf::new(),
             cover: None,
             artists: Vec::new(),
             album: None,
@@ -108,7 +106,7 @@ impl Song {
     }
 
     async fn try_set_cover_url(&mut self) {
-        debug!("searching cover for '{}'", self.uri);
+        debug!("searching cover for '{}'", self.uri.display());
 
         let paths = {
             let c = config().read().await;

--- a/src/dbus/player.rs
+++ b/src/dbus/player.rs
@@ -232,7 +232,7 @@ impl PlayerInterface {
         let mut map = HashMap::new();
 
         if let Some(song) = &s.current_song {
-            let song_url = format!("file://{}", c.music_directory.join(&*song.uri).display());
+            let song_url = format!("file://{}", c.music_directory.join(&song.uri).display());
 
             map.insert("mpris:trackid", id_to_path(song.id).into());
             map.insert("xesam:url", song_url.into());


### PR DESCRIPTION
- Add support for a cover file in cover_directory with the name of the parent directory of the song. (e.g. `~/Music/Album/track.mp3` -> `~/Music/covers/Album.png`)
- Use a PathBuf for song.uri instead of Arc<str>
- Use a vec to save the potential path for covers
- Add a table of contents to the README
- Add some break tags to the README to fix the formatting