### PR TITLE
fix: use as_bytes() before slicing string

### DIFF
--- a/src/util/expand.rs
+++ b/src/util/expand.rs
@@ -46,7 +46,7 @@ pub fn expand_path(str: &str) -> String {
         }
 
         // if the dollar sign is escaped ignore it
-        if is_char_escaped(str[..dollar_idx].as_bytes()) {
+        if is_char_escaped(&str.as_bytes()[..dollar_idx]) {
             ret.push('$');
             continue;
         }


### PR DESCRIPTION
Use as_bytes() before slicing strings in order to not do a second UTF-8 alignment check and prevent a possible panic.